### PR TITLE
受け取れるParamsの調整

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,12 +8,11 @@ class PostsController < ApplicationController
 
   def new
     @post = Post.new
-    # posts/newへのURI直打ちを制限
-    return unless params[:toy].present?
-
-    @rakuten_name = params[:toy]['itemName']
-    @rakuten_url = params[:toy]['itemUrl']
-    @rakuten_image = params[:toy]['mediumImageUrls'][0]
+    if params[:toy]
+      @rakuten_name = params[:toy]['itemName']
+      @rakuten_url = params[:toy]['itemUrl']
+      @rakuten_image = params[:toy]['mediumImageUrls'][0]
+    end
   end
 
   def create

--- a/app/views/toys/_toy.html.erb
+++ b/app/views/toys/_toy.html.erb
@@ -1,11 +1,12 @@
-<% toys.first(20).each do |toy| %>
+<% toys.first(30).each do |toy| %>
   <div class="card card-compact bg-base-100 shadow-2xl my-4 w-7/12 mx-auto">
     <div class="block">
       <%= image_tag (toy['mediumImageUrls'][0]), class: "mx-auto my-4" %>
     </div>
     <%= toy.name %>
     <div class="block">
-      <%=  link_to '投稿する', new_post_path(toy: toy.params), class: "btn btn-primary my-2" %>
+      <% toy_params = { itemName: toy['itemName'], itemUrl: toy['itemUrl'], mediumImageUrls: [toy['mediumImageUrls'][0]] } %>
+      <%=  link_to '投稿する', new_post_path(toy: toy_params), class: "btn btn-primary my-2" %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
**posts_controller.rb**:
   - `@rakuten_name`、`@rakuten_url`、`@rakuten_image`の設定を`if`ブロックで囲むことで、`params[:toy]`が存在する場合にのみ実行されるように変更しています。

 **_toy.html.erb**:
   - 表示するおもちゃの数を20から30に増やしています。
   - 投稿リンクのパラメータを`toy.params`から`toy_params`に変更し、`toy_params`に`itemName`、`itemUrl`、`mediumImageUrls`を含めるように修正しています。